### PR TITLE
Fix some typos and remove css prefixes

### DIFF
--- a/src/components/Confirm.vue
+++ b/src/components/Confirm.vue
@@ -31,19 +31,24 @@ export default {
   .confirm-box {
     background: #ffffff;
   }
+
   .confirm-box .confirm-title {
     padding: 14px
   }
+
   .confirm-box .confirm-title .title {
-    font-size: 24px
+    font-size: 24px;
   }
+
   .confirm-box .confirm-message {
     padding: 0 20px;
   }
+
   .confirm-box .confirm-buttons {
     text-align:  right;
     padding: 10px 20px;
   }
+
   /* .confirm-box .confirm-buttons .button {
     font-size: 20px;
     padding-left: 20px;

--- a/src/components/Confirm.vue
+++ b/src/components/Confirm.vue
@@ -13,8 +13,8 @@
     </div>
   </div>
 </template>
-<script>
 
+<script>
 import Confirmable from '../mixins/confirmable'
 import DialogActions from './DialogActions.vue'
 
@@ -25,7 +25,6 @@ export default {
   layout: [ 'default', { width: 450 } ],
   mixins: [ Confirmable ]
 }
-
 </script>
 
 <style>

--- a/src/components/DefaultLayout.vue
+++ b/src/components/DefaultLayout.vue
@@ -5,7 +5,6 @@
 </template>
 
 <script>
-
 export default {
 }
 </script>

--- a/src/components/DialogLayout.vue
+++ b/src/components/DialogLayout.vue
@@ -1,9 +1,9 @@
 <template>
   <transition name="vdialog-modal">
     <div class="vdialog-modal-mask" @click.self.prevent.stop="dismiss">
-        <div class="vdialog-modal-container" :style="{ 'max-width': getWidth }">
-          <dialog-child v-bind="$options.propsData" ref="dialog" />
-        </div>
+      <div class="vdialog-modal-container" :style="{ 'max-width': getWidth }">
+        <dialog-child v-bind="$options.propsData" ref="dialog" />
+      </div>
     </div>
   </transition>
 </template>

--- a/src/components/DialogLayout.vue
+++ b/src/components/DialogLayout.vue
@@ -9,7 +9,6 @@
 </template>
 
 <script>
-
 export default {
   props: {
     width: Number,

--- a/src/components/DialogOverlay.vue
+++ b/src/components/DialogOverlay.vue
@@ -9,6 +9,7 @@
     </div>
   </transition>
 </template>
+
 <script>
 export default {
   name: 'VDialogOverlay',
@@ -24,6 +25,7 @@ export default {
   }
 }
 </script>
+
 <style>
 /* Absolute Center Spinner */
 .dialog-overlay-loading {

--- a/src/components/DialogOverlay.vue
+++ b/src/components/DialogOverlay.vue
@@ -70,79 +70,42 @@ export default {
   width: 1em;
   height: 1em;
   margin-top: -0.5em;
-  -webkit-animation: spinner 1500ms infinite linear;
-  -moz-animation: spinner 1500ms infinite linear;
-  -ms-animation: spinner 1500ms infinite linear;
-  -o-animation: spinner 1500ms infinite linear;
   animation: spinner 1500ms infinite linear;
   border-radius: 0.5em;
-  -webkit-box-shadow: rgba(255,255,255, 0.75) 1.5em 0 0 0, rgba(255,255,255, 0.75) 1.1em 1.1em 0 0, rgba(255,255,255, 0.75) 0 1.5em 0 0, rgba(255,255,255, 0.75) -1.1em 1.1em 0 0, rgba(255,255,255, 0.75) -1.5em 0 0 0, rgba(255,255,255, 0.75) -1.1em -1.1em 0 0, rgba(255,255,255, 0.75) 0 -1.5em 0 0, rgba(255,255,255, 0.75) 1.1em -1.1em 0 0;
-box-shadow: rgba(255,255,255, 0.75) 1.5em 0 0 0, rgba(255,255,255, 0.75) 1.1em 1.1em 0 0, rgba(255,255,255, 0.75) 0 1.5em 0 0, rgba(255,255,255, 0.75) -1.1em 1.1em 0 0, rgba(255,255,255, 0.75) -1.5em 0 0 0, rgba(255,255,255, 0.75) -1.1em -1.1em 0 0, rgba(255,255,255, 0.75) 0 -1.5em 0 0, rgba(255,255,255, 0.75) 1.1em -1.1em 0 0;
+  box-shadow: rgba(255,255,255, 0.75) 1.5em 0 0 0, rgba(255,255,255, 0.75) 1.1em 1.1em 0 0, rgba(255,255,255, 0.75) 0 1.5em 0 0, rgba(255,255,255, 0.75) -1.1em 1.1em 0 0, rgba(255,255,255, 0.75) -1.5em 0 0 0, rgba(255,255,255, 0.75) -1.1em -1.1em 0 0, rgba(255,255,255, 0.75) 0 -1.5em 0 0, rgba(255,255,255, 0.75) 1.1em -1.1em 0 0;
 }
 
 /* Animation */
 
 @-webkit-keyframes spinner {
   0% {
-    -webkit-transform: rotate(0deg);
-    -moz-transform: rotate(0deg);
-    -ms-transform: rotate(0deg);
-    -o-transform: rotate(0deg);
     transform: rotate(0deg);
   }
   100% {
-    -webkit-transform: rotate(360deg);
-    -moz-transform: rotate(360deg);
-    -ms-transform: rotate(360deg);
-    -o-transform: rotate(360deg);
     transform: rotate(360deg);
   }
 }
 @-moz-keyframes spinner {
   0% {
-    -webkit-transform: rotate(0deg);
-    -moz-transform: rotate(0deg);
-    -ms-transform: rotate(0deg);
-    -o-transform: rotate(0deg);
     transform: rotate(0deg);
   }
   100% {
-    -webkit-transform: rotate(360deg);
-    -moz-transform: rotate(360deg);
-    -ms-transform: rotate(360deg);
-    -o-transform: rotate(360deg);
     transform: rotate(360deg);
   }
 }
 @-o-keyframes spinner {
   0% {
-    -webkit-transform: rotate(0deg);
-    -moz-transform: rotate(0deg);
-    -ms-transform: rotate(0deg);
-    -o-transform: rotate(0deg);
     transform: rotate(0deg);
   }
   100% {
-    -webkit-transform: rotate(360deg);
-    -moz-transform: rotate(360deg);
-    -ms-transform: rotate(360deg);
-    -o-transform: rotate(360deg);
     transform: rotate(360deg);
   }
 }
 @keyframes spinner {
   0% {
-    -webkit-transform: rotate(0deg);
-    -moz-transform: rotate(0deg);
-    -ms-transform: rotate(0deg);
-    -o-transform: rotate(0deg);
     transform: rotate(0deg);
   }
   100% {
-    -webkit-transform: rotate(360deg);
-    -moz-transform: rotate(360deg);
-    -ms-transform: rotate(360deg);
-    -o-transform: rotate(360deg);
     transform: rotate(360deg);
   }
 }

--- a/src/components/DialogOverlay.vue
+++ b/src/components/DialogOverlay.vue
@@ -50,7 +50,6 @@ export default {
   width: 100%;
   height: 100%;
   background: radial-gradient(rgba(112, 112, 112, 0.4), rgba(50, 50, 50, .8));
-  background: -webkit-radial-gradient(rgba(112, 112, 112, 0.4), rgba(50, 50, 50, .8));
 }
 
 /* :not(:required) hides these rules from IE9 and below */

--- a/src/components/DialogOverlaySimple.vue
+++ b/src/components/DialogOverlaySimple.vue
@@ -1,7 +1,6 @@
 <template>
   <transition name="opacity">
     <div
-
       v-if="visible"
       aria-label="loading"
       :style="{zIndex: zIndex}"
@@ -27,8 +26,7 @@ export default {
 }
 </script>
 <style>
-.vc-loading-overlay
-{
+.vc-loading-overlay {
   position: absolute;
   top: 0;
   left: 0;
@@ -38,35 +36,29 @@ export default {
   cursor: wait;
 }
 
-.vc-loading-overlay.vc-light
-{
+.vc-loading-overlay.vc-light {
   background: rgba(0, 0, 0, .5);
 }
 
 .opacity-enter,
-.opacity-leave-to
-{
+.opacity-leave-to {
   opacity: 0.5;
 }
 
-.opacity-enter-active
-{
+.opacity-enter-active {
   transition: opacity .3s ease;
 }
-.opacity-leave-active
-{
+
+.opacity-leave-active {
   transition: all 0.2s cubic-bezier(1.0, 0.5, 0.8, 1.0);
 }
 
-@keyframes rotating
-{
-  from
-  {
+@keyframes rotating {
+  from {
     transform: rotate(0deg);
   }
 
-  to
-  {
+  to {
     transform: rotate(360deg);
   }
 }

--- a/src/components/NotificationLayout.vue
+++ b/src/components/NotificationLayout.vue
@@ -41,53 +41,61 @@ export default {
   }
 }
 </script>
+
 <style>
   .vuedl-notification {
-    display:flex;
-    box-sizing:border-box;
-    position:fixed;
-    box-shadow:0 2px 12px 0 rgba(0,0,0,.1);
-    transition:opacity .3s,left .3s,right .3s,top .4s,bottom .3s,-webkit-transform .3s;
-    transition:opacity .3s,transform .3s,left .3s,right .3s,top .4s,bottom .3s;
-    transition:opacity .3s,transform .3s,left .3s,right .3s,top .4s,bottom .3s,-webkit-transform .3s;
-    overflow:hidden
+    display: flex;
+    box-sizing: border-box;
+    position: fixed;
+    box-shadow: 0 2px 12px 0 rgba(0,0,0,.1);
+    transition: opacity .3s, transform .3s, left .3s, right .3s, top .4s, bottom .3s;
+    overflow: hidden;
   }
+
   .vuedl-notification>div:first-child {
-    width: 100%
+    width: 100%;
   }
+
   .vuedl-notification.right {
-    right: 16px
+    right: 16px;
   }
+
   .vuedl-notification.left {
-    left: 16px
+    left: 16px;
   }
+
   .vuedl-notification__closeBtn {
-    position:absolute;
+    position: absolute;
     top: 9px;
     right: 15px;
     cursor: pointer;
     color: #909399;
     font-size: 22px;
   }
+
   .vuedl-notification__closeBtn:hover {
-    color:#606266
+    color:#606266;
   }
+
   .vuedl-notification-fade-enter.right{
     right: 0;
     transform: translateX(100%);
   }
+
   .vuedl-notification-fade-enter.left{
     left: 0;
     transform: translateX(-100%);
   }
+
   .vuedl-notification-fade-leave-active {
-    opacity: 0
+    opacity: 0;
   }
+  
   @media screen and (max-width: 450px) {
     .vuedl-notification {
-      left: 8px!important;
-      right: 8px!important;
-      max-width: inherit!important;
+      left: 8px !important;
+      right: 8px !important;
+      max-width: inherit !important;
     }
   }
 </style>

--- a/src/components/NotificationLayout.vue
+++ b/src/components/NotificationLayout.vue
@@ -13,13 +13,13 @@
         class="vuedl-notification__closeBtn"
         v-if="showClose"
         @click.stop="close"
-      >×</div>
+        v-html="'×'"
+      />
     </div>
   </transition>
 </template>
 
 <script>
-
 import Notifiable from '../mixins/notifiable'
 
 export default {
@@ -43,15 +43,10 @@ export default {
 </script>
 <style>
   .vuedl-notification {
-    display:-webkit-box;
-    display:-ms-flexbox;
     display:flex;
-    -webkit-box-sizing:border-box;
     box-sizing:border-box;
     position:fixed;
-    -webkit-box-shadow:0 2px 12px 0 rgba(0,0,0,.1);
     box-shadow:0 2px 12px 0 rgba(0,0,0,.1);
-    -webkit-transition:opacity .3s,left .3s,right .3s,top .4s,bottom .3s,-webkit-transform .3s;
     transition:opacity .3s,left .3s,right .3s,top .4s,bottom .3s,-webkit-transform .3s;
     transition:opacity .3s,transform .3s,left .3s,right .3s,top .4s,bottom .3s;
     transition:opacity .3s,transform .3s,left .3s,right .3s,top .4s,bottom .3s,-webkit-transform .3s;
@@ -61,10 +56,10 @@ export default {
     width: 100%
   }
   .vuedl-notification.right {
-    right:16px
+    right: 16px
   }
   .vuedl-notification.left {
-    left:16px
+    left: 16px
   }
   .vuedl-notification__closeBtn {
     position:absolute;
@@ -78,22 +73,20 @@ export default {
     color:#606266
   }
   .vuedl-notification-fade-enter.right{
-    right:0;
-    -webkit-transform:translateX(100%);
-    transform:translateX(100%)
+    right: 0;
+    transform: translateX(100%);
   }
   .vuedl-notification-fade-enter.left{
-    left:0;
-    -webkit-transform:translateX(-100%);
-    transform:translateX(-100%)
+    left: 0;
+    transform: translateX(-100%);
   }
   .vuedl-notification-fade-leave-active {
-    opacity:0
+    opacity: 0
   }
   @media screen and (max-width: 450px) {
     .vuedl-notification {
-      left:8px!important;
-      right:8px!important;
+      left: 8px!important;
+      right: 8px!important;
       max-width: inherit!important;
     }
   }

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -21,7 +21,7 @@ let seed = 1
 export default class Dialog {
   constructor (component, { layout, container } = {}) {
     if (!component) {
-      throw Error('Component was not setted')
+      throw Error('Component was not set')
     }
     this._layout = layout || { component: DefaultLayout, options: {} }
     this._component = component

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 // Import vue components
 import DialogManager from './manager'
 import Overlay from './components/DialogOverlay.vue'
+
 // install function executed by Vue.use()
 function install (Vue, options = {}) {
   if (install.installed) return
@@ -16,7 +17,7 @@ function install (Vue, options = {}) {
       }
     })
   } else {
-    console.warn(`Property ${property} is already defigned in Vue prototype`)
+    console.warn(`Property ${property} is already defined in Vue prototype`)
   }
 }
 

--- a/src/manager.js
+++ b/src/manager.js
@@ -109,7 +109,6 @@ export default class DialogManager {
   async show (component, options = {}) {
     const dlg = this.create(component)
     const overlayName = dlg.hasAsyncPreload ? (this.getComponentProperty(component, 'overlay') || 'default') : false
-
     const overlay = overlayName && this._overlays[overlayName] && this.overlay(overlayName)
 
     overlay && overlay.show()

--- a/src/mixins/layoutable.js
+++ b/src/mixins/layoutable.js
@@ -2,7 +2,6 @@ import Activable from './activable'
 
 export default {
   name: 'Layoutable',
-
   mixins: [ Activable ],
   inheritAttrs: false,
 
@@ -54,6 +53,7 @@ export default {
       this.isActive = false
     }
   },
+  
   beforeDestroy () {
     if (typeof this.$el.remove === 'function') {
       this.$el.remove()

--- a/src/mixins/notifiable.js
+++ b/src/mixins/notifiable.js
@@ -91,7 +91,7 @@ export default {
     },
     keydown (e) {
       if (e.keyCode === 46 || e.keyCode === 8) {
-        this.clearTimer() // detele key
+        this.clearTimer() // delete key
       } else if (e.keyCode === 27) { // esc key
         this.close()
       } else {


### PR DESCRIPTION
Prefixes are slowly getting outdated. Projects like Autoprefixer can automate the process in its entirety without us needing to find out if a prefix is needed any more, or the feature is now stable and the prefix should be dropped. It uses data from caniuse.com, a very good reference site for all things related to browser support.